### PR TITLE
Create standup-checklist.md based on GT version

### DIFF
--- a/meeting_templates/standup-checklist.md
+++ b/meeting_templates/standup-checklist.md
@@ -11,7 +11,7 @@ We aim at finishing the stand up in 25 mins. Longer discussions should be held i
 
 1. What needs to be done to reach the goal of the sprint?
 
-## Chair asks each individual (Leon, Christiaan, Elena, Yang, others?):
+## Chair asks each individual (Leon, Christiaan, Elena, Yang, Patrick, others?):
 
 1. Is there interesting progress for the rest of the team to know?
 1. How much time can you spend until the next stand up?

--- a/meeting_templates/standup-checklist.md
+++ b/meeting_templates/standup-checklist.md
@@ -5,7 +5,7 @@ Backup: Elena
 
 We aim at finishing the stand up in 25 mins. Longer discussions should be held in another meeting outside the standup.
 
-## Chair reminds the team of the goal of the sprint (see [ROADMAP](https://github.com/NLeSC/generalization/blob/master/ROADMAP.md))
+## Chair reminds the team of the goal of the sprint (todo: link to goal)
 
 ## Chair asks the product owner (if there is one otherwise chair will):
 
@@ -21,8 +21,8 @@ We aim at finishing the stand up in 25 mins. Longer discussions should be held i
 ## Collectively
 
 1. Discuss:
-   1. issues with "standup" labeled in [GT repository](https://github.com/dianna-ai/dianna/issues?q=is%3Aissue+is%3Aopen+label%3Astandup)
-   1. pull requests in [GT repository](https://github.com/dianna-ai/dianna/pulls)
+   1. [Issues with "standup" labeled](https://github.com/dianna-ai/dianna/issues?q=is%3Aissue+is%3Aopen+label%3Astandup)
+   1. [pull requests](https://github.com/dianna-ai/dianna/pulls)
    1. Does anyone want to do pair programming? Make an appointment.
 1. Any other business, e.g.
    - Issues unrelated to the sprint

--- a/meeting_templates/standup-checklist.md
+++ b/meeting_templates/standup-checklist.md
@@ -5,11 +5,11 @@ Backup: Elena
 
 We aim at finishing the stand up in 25 mins. Longer discussions should be held in another meeting outside the standup.
 
-## Chair reminds the team of the goal of the sprint (todo: link to goal)
+## Chair reminds the team of the goal of the sprint (see https://github.com/dianna-ai/dianna/projects)
 
 ## Chair asks the product owner (if there is one otherwise chair will):
 
-1. What needs to be done to reach the goal of the sprint?
+1. What currently needs to be done in order to reach the goal of the sprint?
 
 ## Chair asks each individual (Leon, Christiaan, Elena, Yang, Patrick, others?):
 

--- a/meeting_templates/standup-checklist.md
+++ b/meeting_templates/standup-checklist.md
@@ -1,0 +1,29 @@
+# Standup checklist
+
+Chair: Chris
+Backup: Elena
+
+We aim at finishing the stand up in 25 mins. Longer discussions should be held in another meeting outside the standup.
+
+## Chair reminds the team of the goal of the sprint (see [ROADMAP](https://github.com/NLeSC/generalization/blob/master/ROADMAP.md))
+
+## Chair asks the product owner (if there is one otherwise chair will):
+
+1. What needs to be done to reach the goal of the sprint?
+
+## Chair asks each individual (Leon, Christiaan, Elena, Yang, others?):
+
+1. Is there interesting progress for the rest of the team to know?
+1. How much time can you spend until the next stand up?
+1. What do you plan to work on until the next stand up? Is it helping us to reach the goal of the sprint?
+1. Is anything blocking your progress? Do you need help?
+
+## Collectively
+
+1. Discuss:
+   1. issues with "standup" labeled in [GT repository](https://github.com/dianna-ai/dianna/issues?q=is%3Aissue+is%3Aopen+label%3Astandup)
+   1. pull requests in [GT repository](https://github.com/dianna-ai/dianna/pulls)
+   1. Does anyone want to do pair programming? Make an appointment.
+1. Any other business, e.g.
+   - Issues unrelated to the sprint
+   - Announcements


### PR DESCRIPTION
I copied the standup-checklist we used for last standup meeting from the Generalization Team repo and made some adjustments so it will work better for us.

I would like anyone from our team to have a quick look and approve/request changes. I think that's a good habit instead of anyone just pushing changes on my own.